### PR TITLE
[#20][FIX] OpenGraph thumbnail 이미지 경로 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "meta_title": "쉬운지식",
     "meta_description": "세상 모든 지식 & 정보격차 해소를 위합니다",
     "meta_url": "https://knowease-inc.github.io/",
-    "meta_image": "https://knowease-inc.github.io/thumbnail/knowease_og_thumbnail_20210608.png"
+    "meta_image": "https://knowease-inc.github.io/img/thumbnail/knowease_og_thumbnail_20210608.png"
   },
   "scripts": {
     "dev": "nuxt",


### PR DESCRIPTION
   - 수정이유: OpenGraph 이미지 경로 잘못되어 미표시
   - 수정내용: /img/ 경로 추가

## 이 PR로 아래의 이슈가 해결될 수 있습니다
> 이 PR이 성공적으로 merge될 경우 **자동적으로 클로즈할** 이슈 번호를 **1개 이상** 적어주세요.
 - resolved: #20

## 이 PR이 머지될 경우 혹시나 이런 문제가 있을 수도 있습니다
> **혹시나 예상되는** 서비스 운영 관점의 문제점과, 문제발생시 대응방법을 **1개 이상** 적어주세요.
 - [ ] 이미지 수정 시 파일명 또는 경로 수정 가능 : 경로 일치 시킬 것
