### PR TITLE
[#15][FIX] 두 Carousel.vue 통일

### DIFF
--- a/components/pages.index/Carousel.vue
+++ b/components/pages.index/Carousel.vue
@@ -15,7 +15,6 @@
       >
         <v-sheet
           height="100%"
-          width="100%"
           color="rgba(0,0,0,0)"
           class="d-flex justify-start align-center pa-4"
         >


### PR DESCRIPTION
   - 수정이유: 에러나지 않는 쪽의 Carousel 코드와 최대한 일치 필요
   - 수정내용: index의 Carousel.vue 냐 width="100%" 삭제

## 이 PR로 아래의 이슈가 해결될 수 있습니다
> 이 PR이 성공적으로 merge될 경우 **자동적으로 클로즈할** 이슈 번호를 **1개 이상** 적어주세요.
 - resolved: #15

## 이 PR이 머지될 경우 혹시나 이런 문제가 있을 수도 있습니다
> **혹시나 예상되는** 서비스 운영 관점의 문제점과, 문제발생시 대응방법을 **1개 이상** 적어주세요.
 - [ ] 문제 지속될 수 있음 : 두 페이지 다른 점에서 문제가 생긴 것 맞는지 근거부터 다시 찾을 것
