### PR TITLE
[#26][FIX] default.vue 내 currentRoute 조건 수정

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -57,14 +57,10 @@ import MainFooter from '@/components/layouts.default/MainFooter.vue'
   computed: {
     onKnowease() {
       const currentRoute: string = this.$route.path
-      if (
-        currentRoute === '/service/easyxplain/introduce' ||
-        currentRoute === '/service/easyxplain/regulations' ||
-        currentRoute === '/service/easyxplain/achievements'
-      ) {
-        return false
-      } else {
+      if (currentRoute === '/') {
         return true
+      } else {
+        return false
       }
     },
   },


### PR DESCRIPTION
   - 수정이유: 개별 route 직접 접속 시 법인 로고가 뜸
   - 수정내용: currentRoute가 true인 경우를 '/' route.path일 때로 변경
   - 세부내용: 예를 들어 '/introduce' 직접 접속 시 마지막에 '/'가 붙기 때문이었음

## 이 PR로 아래의 이슈가 해결될 수 있습니다
> 이 PR이 성공적으로 merge될 경우 **자동적으로 클로즈할** 이슈 번호를 **1개 이상** 적어주세요.
 - resolved: #26

## 이 PR이 머지될 경우 혹시나 이런 문제가 있을 수도 있습니다
> **혹시나 예상되는** 서비스 운영 관점의 문제점과, 문제발생시 대응방법을 **1개 이상** 적어주세요.
 - [ ] 향후 페이지가 늘어난 경우 : 페이지별로 로고 잘 바뀌도록 대처
