### PR TITLE
[#36][FEATURE] EASYXPLAIN 서비스 직접 연결 링크 해제

### DIFF
--- a/components/layouts.default/TopBar.vue
+++ b/components/layouts.default/TopBar.vue
@@ -21,11 +21,7 @@
 
     <!-- Start : Easyxplain image -->
     <v-toolbar-items v-else>
-      <v-btn
-        text
-        href="https://frontend.easyxplain.com/"
-        active-class="no-active"
-      >
+      <v-btn text active-class="no-active" @click.prevent="notReadyNotice()">
         <v-img
           :src="appBar.easyxplain.imgSrc"
           :alt="appBar.easyxplain.title"
@@ -94,6 +90,10 @@ import MainFooter from '@/components/layouts.default/MainFooter.vue'
   methods: {
     easterEgg() {
       const text: string = '어떻게 알고 찾았죠...?'
+      alert(text)
+    },
+    notReadyNotice() {
+      const text: string = '본 서비스는 오픈 준비중입니다.'
       alert(text)
     },
   },

--- a/components/pages.index/Services.vue
+++ b/components/pages.index/Services.vue
@@ -36,6 +36,7 @@
               <v-btn
                 text
                 small
+                :disabled="content.shortcut.href === undefined ? true : false"
                 :color="linkBtnColor"
                 :href="content.shortcut.href"
               >
@@ -90,6 +91,7 @@
             <v-btn
               text
               x-small
+              :disabled="content.shortcut.href === undefined ? true : false"
               :color="linkBtnColor"
               :href="content.shortcut.href"
             >
@@ -131,18 +133,18 @@ class PagesIndexServices extends Vue {
   @Provide() content: {
     name: string
     explanation: string
-    href: string
-    shortcut: { name: string; href: string }
+    href: string | undefined
+    shortcut: { name: string; href: string | undefined }
     introduce: { name: string; to: string }
     regulations: { name: string; to: string }
   } = {
     name: 'EASYXPLAIN',
     explanation:
       '짧고 쉬운 전문/기술용어 설명과 모든 가이드를 얻거나 제공하고 쉽게 설명하는 능력을 인정 받는 플랫폼',
-    href: 'https://frontend.easyxplain.com/',
+    href: undefined, // 'https://frontend.easyxplain.com/',
     shortcut: {
-      name: '바로가기',
-      href: 'https://frontend.easyxplain.com/',
+      name: '(준비중)', // '바로가기',
+      href: undefined, // 'https://frontend.easyxplain.com/',
     },
     introduce: {
       name: '소개',


### PR DESCRIPTION
   - 수정이유: EASYXPLAIN 서비스 오픈 전 링크 제거
   - 수정내용: href, to 링크 url disabled
   - 세부내용: 서비스 오픈 시 본 commit revert로 해결

## 이 PR로 아래의 이슈가 해결될 수 있습니다
> 이 PR이 성공적으로 merge될 경우 **자동적으로 클로즈할** 이슈 번호를 **1개 이상** 적어주세요.
 - resolved: #36

## 이 PR이 머지될 경우 혹시나 이런 문제가 있을 수도 있습니다
> **혹시나 예상되는** 서비스 운영 관점의 문제점과, 문제발생시 대응방법을 **1개 이상** 적어주세요.
 - [ ] 서비스 오픈 시 링크 재개 : 본 commit revert
