### PR TITLE
[#88][FEATURE] Naver 사이트 소유 확인용 <meta> 태그 추가

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -105,6 +105,12 @@ export default {
         name: 'google-site-verification',
         content: 'NXprhyX8ZG7MoveZppYftz0xIl5kkkYSK9xJ4tXQPLk',
       },
+      /* For Naver Web Master
+      <meta name="naver-site-verification" content="b9f47832d1b3a168ae4076e70eb986dd85f0520c" /> */
+      {
+        name: 'naver-site-verification',
+        content: 'b9f47832d1b3a168ae4076e70eb986dd85f0520c',
+      },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
   },


### PR DESCRIPTION
  - 수정이유: 쉬운지식 사이트의 네이버 등록 필요
  - 수정내용: 네이버에서 요청한 확인용 <meta> 태그 추가

## 이 PR로 아래의 이슈가 해결될 수 있습니다
> 이 PR이 성공적으로 merge될 경우 **자동적으로 클로즈할** 이슈 번호를 **1개 이상** 적어주세요.
 - resolved: #88

## 이 PR이 머지될 경우 혹시나 이런 문제가 있을 수도 있습니다
> **혹시나 예상되는** 서비스 운영 관점의 문제점과, 문제발생시 대응방법을 **1개 이상** 적어주세요.
 - [ ] 네이버에서 확인 안됨 : 원본 그대로 태그 입력할 것
