### PR TITLE
[#123][FIX] 채용 페이지에서 회사 로고 출력, 채용 메뉴 추가

### DIFF
--- a/components/layouts.default/TopBar.vue
+++ b/components/layouts.default/TopBar.vue
@@ -114,6 +114,7 @@ class LayoutDefaultTopBar extends Vue {
   }> = [
     { title: true, name: '게타(GET-A)', to: undefined },
     { title: false, name: '회사 소개', to: '/' },
+    { title: false, name: '채용 공고', to: '/recruit' },
     { title: true, name: '미닛', to: undefined },
     { title: false, name: '서비스 소개', to: '/service/meaniit/introduce' },
     {
@@ -127,7 +128,11 @@ class LayoutDefaultTopBar extends Vue {
   // computed
   get onKnowease() {
     const currentRoute: string = this.$route.path
-    return currentRoute === '/' || currentRoute === '/recruit'
+    return (
+      currentRoute === '/' ||
+      currentRoute === '/recruit' ||
+      currentRoute === '/recruit/'
+    )
   }
 
   // method

--- a/components/pages.recruit/RecruitInfos.vue
+++ b/components/pages.recruit/RecruitInfos.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card flat tile>
+  <v-card flat tile class="mt-sm-8 mt-4">
     <v-container fluid class="pt-0">
       <v-row justify="center" align="center" no-gutters>
         <!-- Start: Recruit Infos -->


### PR DESCRIPTION
    - 수정이유: 채용 페이지에서 회사 로고 출력, 채용 메뉴 필요
    - 수정내용: 로고 출력 조건 수정, 채용 공고 이동 메뉴 추가

## 이 PR로 아래의 이슈가 해결될 수 있습니다
> 이 PR이 성공적으로 merge될 경우 **자동적으로 클로즈할** 이슈 번호를 **1개 이상** 적어주세요.
 - resolved: #123

## 이 PR이 머지될 경우 혹시나 이런 문제가 있을 수도 있습니다
> **혹시나 예상되는** 서비스 운영 관점의 문제점과, 문제발생시 대응방법을 **1개 이상** 적어주세요.
 - [ ] 지원하기 버튼 미동작 : URL 및 구글 지원폼 확인
