### PR TITLE
[#238][FIX] 아이폰(사파리)에서의 동영상 출력 오류

### DIFF
--- a/components/pages.index/Timeline.vue
+++ b/components/pages.index/Timeline.vue
@@ -19,7 +19,7 @@
 
       <v-col cols="12" sm="10" class="d-sm-flex py-0 py-sm-3">
         <v-col cols="12" sm="6" :class="xs ? 'd-flex justify-center pt-0' : ''">
-          <video :width="xs ? 350 : 700" autoplay muted loop>
+          <video :width="xs ? 350 : 700" autoplay playsinline muted loop>
             <source src="/img/new/history.mp4" type="video/mp4" />
             Your browser does not support the video tag.
           </video>

--- a/components/pages.service.meaniit.introduce/Differentiation.vue
+++ b/components/pages.service.meaniit.introduce/Differentiation.vue
@@ -28,6 +28,7 @@
             ref="videoRefs"
             :src="item.icon"
             autoplay
+            playsinline
             loop
             muted
             style="width: 60px; height: 60px"
@@ -75,6 +76,7 @@
             ref="videoRefs"
             :src="item.icon"
             autoplay
+            playsinline
             loop
             muted
             style="width: 60px; height: 60px"

--- a/components/pages.service.meaniit.introduce/TopIntro.vue
+++ b/components/pages.service.meaniit.introduce/TopIntro.vue
@@ -71,6 +71,7 @@
           ref="videoRef"
           :src="imgs.video"
           autoplay
+          playsinline
           loop
           muted
           class="responsive-image"
@@ -105,6 +106,7 @@
             ref="videoRef"
             :src="imgs.video"
             autoplay
+            playsinline
             loop
             muted
             style="height: 350px"


### PR DESCRIPTION
  - 수정이유: 아이폰 사용자를 위한 video 태그 오류 해결
  - 수정내용: ios에서 자동재생을 위한 video 태그 속성 추가_playsinline

## 이 PR로 아래의 이슈가 해결될 수 있습니다
> 이 PR이 성공적으로 merge될 경우 **자동적으로 클로즈할** 이슈 번호를 "#"을 붙여서 **1개 이상** 적어주세요.

 - resolved: #238

## 아래의 내용과 같이 개발상 정상적으로 동작함을 확인하였습니다.
> 개발시 정상적으로 동작하였음을 확인할 수 있는 스크린샷, 동작 로그 등을 **1개 이상** 적어주세요.

 - 아이폰에서 동영상 정상 출력

## 이 PR이 머지될 경우, 혹시나 이런 문제가 있을 수도 있습니다
> **혹시나 예상되는** 서비스 운영상 **1개 이상** 적어주세요.

 - 에러 미해결

## 이 PR이 머지된 후 예상되는 문제가 실제로 발생하면 이러한 대응이 필요합니다.
> 실제 문제가 발생할 경우, 서비스 운영을 정상화시킬 수 있는 방법을 적어주세요.

 - mp4 파일 교체
