### PR TITLE
[#247][FEATURE] Google Ads 위한 gtag 스크립트 추가

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -92,6 +92,29 @@ export default defineNuxtConfig({
         { rel: 'alternate', hreflang: 'en', href: 'https://www.get-a.io/en' },
         { rel: 'alternate', hreflang: 'ko', href: 'https://www.get-a.io/' },
       ],
+      script: [
+        {
+          innerHTML: `
+            function gtag_report_conversion(url) {
+              var callback = function () {
+                if (typeof(url) != 'undefined') {
+                  window.location = url;
+                }
+              };
+              gtag('event', 'conversion', {
+                  'send_to': 'AW-11494161709/uJAXCN7Djf0ZEK366-gq',
+                  'value': 1.0,
+                  'currency': 'KRW',
+                  'event_callback': callback
+              });
+              return false;
+            }
+          `,
+          type: 'text/javascript'
+        }
+      ],
+      // 인라인 스크립트 사용을 위해 sanitize 옵션 비활성화
+      __dangerouslyDisableSanitizers: ['script']
     },
   },
 


### PR DESCRIPTION
  - 수정이유: Google Ads 위한 gtag 스크립트 추가 필요
  - 수정내용: Google Ads 위한 gtag 스크립트 추가
  - 세부내용:
    - `__dangerouslyDisableSanitizers` 옵션은 정적 사이트이기에 추가 가능한 것으로 동적 데이터가 존재하는 경우 제거

## 이 PR로 아래의 이슈가 해결될 수 있습니다
> 이 PR이 성공적으로 merge될 경우 **자동적으로 클로즈할** 이슈 번호를 "#"을 붙여서 **1개 이상** 적어주세요.

 - resolved: #247

## 아래의 내용과 같이 개발상 정상적으로 동작함을 확인하였습니다.
> 개발시 정상적으로 동작하였음을 확인할 수 있는 스크린샷, 동작 로그 등을 **1개 이상** 적어주세요.

 - TBD

## 이 PR이 머지될 경우, 혹시나 이런 문제가 있을 수도 있습니다
> **혹시나 예상되는** 서비스 운영상 **1개 이상** 적어주세요.

 - TBD

## 이 PR이 머지된 후 예상되는 문제가 실제로 발생하면 이러한 대응이 필요합니다.
> 실제 문제가 발생할 경우, 서비스 운영을 정상화시킬 수 있는 방법을 적어주세요.

 - TBD
